### PR TITLE
lge_battery: Use EPROBE_DEFER instead of ENODEV during probe

### DIFF
--- a/drivers/power/lge_battery.c
+++ b/drivers/power/lge_battery.c
@@ -670,25 +670,25 @@ static int bm_init(struct battery_manager *bm)
 	bm->batt_psy = power_supply_get_by_name("battery");
 	if (!bm->batt_psy) {
 		pr_bm(ERROR, "Couldn't get batt_psy\n");
-		return -ENODEV;
+		return -EPROBE_DEFER;
 	}
 
 	bm->usb_psy = power_supply_get_by_name("usb");
 	if (!bm->usb_psy) {
 		pr_bm(ERROR, "Couldn't get usb_psy\n");
-		return -ENODEV;
+		return -EPROBE_DEFER;
 	}
 
 	bm->pl_psy = power_supply_get_by_name("parallel");
 	if (!bm->pl_psy) {
 		pr_bm(ERROR, "Couldn't get pl_psy\n");
-		return -ENODEV;
+		return -EPROBE_DEFER;
 	}
 
 	bm->bms_psy = power_supply_get_by_name("bms");
 	if (!bm->bms_psy) {
 		pr_bm(ERROR, "Couldn't get bms_psy\n");
-		return -ENODEV;
+		return -EPROBE_DEFER;
 	}
 
 	rc = bm_get_property(bm->batt_psy,


### PR DESCRIPTION
See the commit message for further technical details.

I don't know if this is an issue for you guys but it's easy to verify:
```bash
dmesg | grep lge
[    1.375729] lge_battery: bm_init: Couldn't get pl_psy
[    1.375736] lge_battery: lge_battery_probe: bm_init fail
```

I've been using [this commit](https://github.com/nathanchance/wahoo/commit/32d86fe336407f0a8d78b2b496b7096f5000aa11) in my tree since 8.0 but I decided to take an actual look at it today and I believe this is a better fix since it does what the probe function intends, plus it mirrors what the htc_battery driver does.